### PR TITLE
Add org mode link list format

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ https://github.com/piroor/copy-selected-tabs-to-clipboard/actions?query=workflow
 |Markdown Link List|`%TST_INDENT(  )%* [%TITLE%](%URL% "%TITLE%")`|
 |URL without query|`%REPLACE("%URL%", "\?.*$", "")%`|
 |URL without query except Google|`%REPLACE("%URL%", "^(?!\w+://[^/]*\.google\.[^/]*/.*)\?.*$", "$1")`|
+|Org Mode Link List|`*%TST_INDENT(*)% [[%URL%][%TITLE%]]`|
 


### PR DESCRIPTION
I think it would be great to add [org mode](https://orgmode.org/) style links.
Org mode syntax is supported out of the box in [PlantUML](https://plantuml.com/mindmap-diagram) so it's that makes possible to make maps of tab trees.