### PR TITLE
common/commands: Do not use await to avoid race condition

### DIFF
--- a/common/commands.js
+++ b/common/commands.js
@@ -126,7 +126,8 @@ export async function copyToClipboard(tabs, format) {
   if (!richText) {
     log('trying to write text to clipboard via Clipboard API');
     try {
-      await navigator.clipboard.writeText(plainText);
+      // Do not use await here because it could hang Firefox. See https://bugs.kde.org/show_bug.cgi?id=446581
+      navigator.clipboard.writeText(plainText);
       notifyCopied(tabs.length, plainText);
       return;
     }
@@ -242,7 +243,8 @@ export async function copyToClipboard(tabs, format) {
 
   log('failed to write rich text data to the clipboard, so fallback to plain text data copy via Clipboard API');
   try {
-    await navigator.clipboard.writeText(plainText);
+    // Do not use await here because it could hang Firefox. See https://bugs.kde.org/show_bug.cgi?id=446581
+    navigator.clipboard.writeText(plainText);
     notifyCopied(tabs.length, plainText);
     return;
   }


### PR DESCRIPTION
Analysis from nyanpasu64:

On KDE Plasma X11, with Klipper (clipboard history) added to plasmashell,
and Firefox with "Copy Selected Tabs to Clipboard" installed, trying
to use the extension often causes Firefox and plasmashell (and any app
trying to paste) to deadlock and hang.

When you use the extension to copy a tab list, Firefox sends a "clipboard
changed" event (through X11 I assume, not sure) and attempts to send a
notification through D-Bus (`notify_notification_show () at
/usr/lib/libnotify.so.4` blocks on `g_dbus_connection_send_message_with_reply_sync`).

Meanwhile plasmashell can't process the notification and unblock Firefox,
because the Klipper plasmashell plugin is blocked trying to grab the
clipboard contents (`QMimeData::text()` blocks on `QXcbClipboard::getSelection`
and `QXcbClipboard::waitForClipboardEvent`). plasmashell/Klipper asks Xorg to ask
Firefox for clipboard contents. But Firefox can't provide clipboard contents
until it's done showing a notification, and plasmashell won't show the
notification until it gets the clipboard contents.

And both apps lock up for 10 seconds. And in the end, plasmashell gives up trying
to grab clipboard contents, processes the notification, and both programs get
unblocked (but Klipper is missing the clipboard entry).

To avoid hanging, we just need to remove `await` so the race condition can
be effectively avoided.

See also: https://bugs.kde.org/show_bug.cgi?id=446581