### PR TITLE
Fixed typo in common.js with HTML Link

### DIFF
--- a/common/common.js
+++ b/common/common.js
@@ -25,7 +25,7 @@ defaultClipboardFormats.push({
 */
 defaultClipboardFormats.push({
   label:  browser.i18n.getMessage('context_clipboard_html_link_label'),
-  format: '<a title="%HTML_SAFE(%TITLE%)%" href="%HTML_SAFE(%URL)%%">%HTML_SAFE(%TITLE%)%</a>'
+  format: '<a title="%HTML_SAFE(%TITLE%)%" href="%HTML_SAFE(%URL%)%">%HTML_SAFE(%TITLE%)%</a>'
 });
 defaultClipboardFormats.push({
   label:  browser.i18n.getMessage('context_clipboard_markdown_label'),


### PR DESCRIPTION
The `HTML Link` option has issues parsing with this typo. No typo in `README.md`.